### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,7 +12,7 @@ SonoffDualButton	KEYWORD1
 
 setup	KEYWORD2
 handleButton	KEYWORD2
-setLed  KEYWORD2
+setLed	KEYWORD2
 setRelays	KEYWORD2
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords